### PR TITLE
products/new 不要パンくずコート削除

### DIFF
--- a/app/views/products/_product-header.html.haml
+++ b/app/views/products/_product-header.html.haml
@@ -1,4 +1,3 @@
 %header.product-header
   = link_to "#" do
     = image_tag("logo.svg", alt: "mercari", class: "product-header__logo")
-    = breadcrumb :products


### PR DESCRIPTION
# WHAT
products/newページ内の不要パンくずコート削除いたしました。

# WHY
コード作成段階の記述が残っていたために削除を行いました。
