### PR TITLE
Userモデル nicknameカラム バリデーション削除

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
           omniauth_providers: %i[facebook google_oauth2]
 
 
-  validates :nickname, presence: true, uniqueness: true
+  validates :nickname, presence: true
 
   has_one :profile
   has_many :products

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -51,12 +51,6 @@ describe User, class: User do
     end
 
 #重複により登録不可
-    it "is invalid with a duplicate nickname address" do
-      user = create(:user)
-      another_user = build(:user)
-      another_user.valid?
-      expect(another_user.errors[:nickname]).to include("はすでに存在します")
-    end
 
     it "is invalid with a duplicate email address" do
       user = create(:user)
@@ -66,5 +60,5 @@ describe User, class: User do
     end
 
   end
-  
+
 end


### PR DESCRIPTION
# WHAT
Userモデル nicknameカラムの重複禁止のバリデーションを削除いたしました。

# WHY
emailでの重複登録制限を設けており、
nickname重複のバリデーションを不要としたため。

