### PR TITLE
本番環境Google認証

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ end
 
 group :production do
   gem 'unicorn'
+  gem 'unicorn-worker-killer'
 end
 
 gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.2.5)
+    get_process_mem (0.2.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     gretel (3.0.9)
@@ -331,6 +332,9 @@ GEM
     unicorn (5.5.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    unicorn-worker-killer (0.4.4)
+      get_process_mem (~> 0)
+      unicorn (>= 4, < 6)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -388,6 +392,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   unicorn
+  unicorn-worker-killer
   web-console (>= 3.3.0)
   wicked
 

--- a/config.ru
+++ b/config.ru
@@ -3,3 +3,11 @@
 require_relative 'config/environment'
 
 run Rails.application
+
+# Unicorn worker_killer config
+if ENV['RAILS_ENV'] == 'production'
+  require 'unicorn/worker_killer'
+  CHECK_CYCLE = 16
+  # use Unicorn::WorkerKiller::MaxRequests, 3072, 4096
+  use Unicorn::WorkerKiller::Oom, (192*(1024**2)), (256*(1024**2))
+end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,5 @@
 server '54.64.150.97', user: 'ec2-user', roles: %w{app db web}
+server '52.196.209.2', user: 'ec2-user', roles: %w{app db web}
 
 set :rails_env, "production"
 set :unicorn_rack_env, "production"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -26,7 +26,7 @@ Devise.setup do |config|
 
   config.sign_out_via = :delete
 
-  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], scope: 'email', redirect_uri: "#{ENV['HOST']}/users/auth/google_oauth2/callback"
+  config.omniauth :google_oauth2, Rails.application.secrets.google_client_id, Rails.application.secrets.google_client_secrets, scope: 'email', redirect_uri: "#{Rails.application.secrets.host}/users/auth/google_oauth2/callback"
 
   config.omniauth :facebook, ENV['FACEBOOK_CLIENT_ID'], ENV['FACEBOOK_CLIENT_SECRET'], scope: 'email', info_fields: 'email', callback_url: "http://localhost:3000/users/auth/facebook/callback"
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -26,7 +26,7 @@ Devise.setup do |config|
 
   config.sign_out_via = :delete
 
-  config.omniauth :google_oauth2, Rails.application.secrets.google_client_id, Rails.application.secrets.google_client_secrets, scope: 'email', redirect_uri: "#{Rails.application.secrets.host}/users/auth/google_oauth2/callback"
+  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], scope: 'email', redirect_uri: "#{Rails.application.secrets.host}/users/auth/google_oauth2/callback"
 
   config.omniauth :facebook, ENV['FACEBOOK_CLIENT_ID'], ENV['FACEBOOK_CLIENT_SECRET'], scope: 'email', info_fields: 'email', callback_url: "http://localhost:3000/users/auth/facebook/callback"
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -26,7 +26,7 @@ Devise.setup do |config|
 
   config.sign_out_via = :delete
 
-  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], scope: 'email', redirect_uri: "http://localhost:3000/users/auth/google_oauth2/callback"
+  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], scope: 'email', redirect_uri: "#{ENV['HOST']}/users/auth/google_oauth2/callback"
 
   config.omniauth :facebook, ENV['FACEBOOK_CLIENT_ID'], ENV['FACEBOOK_CLIENT_SECRET'], scope: 'email', info_fields: 'email', callback_url: "http://localhost:3000/users/auth/facebook/callback"
 end


### PR DESCRIPTION
# WHAT
・本番環境のGoogleでのログインと新規登録を行えるようにロードバランサー等の導入を行い、それに伴う調整をしました
・unicornのメモリが一杯になってデプロイできない問題の解決のためにgemを追加しました
#WHY
本番環境でGoogleの認証が行えることでユーザーの利便性を上げるために実装しました。
unicornのメモリが一杯で起動できない問題の解決のために変更しました。