### PR TITLE
本番環境でのFacebookでのログインと新規登録の実装

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -28,5 +28,5 @@ Devise.setup do |config|
 
   config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], scope: 'email', redirect_uri: "#{Rails.application.secrets.host}/users/auth/google_oauth2/callback"
 
-  config.omniauth :facebook, ENV['FACEBOOK_CLIENT_ID'], ENV['FACEBOOK_CLIENT_SECRET'], scope: 'email', info_fields: 'email', callback_url: "http://localhost:3000/users/auth/facebook/callback"
+  config.omniauth :facebook, ENV['FACEBOOK_CLIENT_ID'], ENV['FACEBOOK_CLIENT_SECRET'], scope: 'email', info_fields: 'email', callback_url: "#{Rails.application.secrets.host}/users/auth/facebook/callback"
 end


### PR DESCRIPTION
# WHAT
本番環境でFacebookのログインと新規登録を行えるように調整しました。
callback_urlをsecrets.ymlから取得し、開発環境と本番環境でのurlを変えるようにしました。
#WHY
本番環境でFacebookでのログインや新規登録を行えるようにし、ユーザーの利便性を良くする為。