### PR TITLE
購入ページ修正

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -95,6 +95,7 @@ class ProductsController < ApplicationController
     customer_id = Payjp::Customer.retrieve(customer.customer_id)
     @customer = customer_id.cards.data[0]
     @product = Product.find(params[:id])
+    @profile = @product.user.profile
   end
 
   def search

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -18,4 +18,20 @@ module ProductsHelper
     end
   end
 
+  def zip_code(profile)
+    profile.zip_code.to_s.split(/(?<=^.{3})/).join('-')
+  end
+
+  def set_address(profile)
+    if profile.address2 == nil
+      profile.prefecture + " " + profile.city + profile.address1
+    else
+      profile.prefecture + " " + profile.city + profile.address1 + profile.address2
+    end
+  end
+
+  def set_name(profile)
+      profile.first_name + " " + profile.last_name
+  end
+
 end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -23,11 +23,9 @@ module ProductsHelper
   end
 
   def set_address(profile)
-    if profile.address2 == nil
-      profile.prefecture + " " + profile.city + profile.address1
-    else
-      profile.prefecture + " " + profile.city + profile.address1 + profile.address2
-    end
+    user_address = profile.prefecture + " " + profile.city + profile.address1
+    user_address = user_address + profile.address2 if profile.address2.present?
+    return user_address
   end
 
   def set_name(profile)

--- a/app/views/products/buy.html.haml
+++ b/app/views/products/buy.html.haml
@@ -8,33 +8,34 @@
       %section.buy-content.buy-item
         .buy-content-inner
           %h3.buy-item-image
-            = image_tag "https://placehold.jp/150x150.png"
+            = image_tag "#{@product.images[0].image_path_url}"
           %p.buy-item-name.bold
-            テスト商品
+            #{@product.name}
           = form_for @product, url: {controller: "trades", action: "update"} do |f|
             = f.hidden_field :price, value: @product.price
             %p.buy-price-ja.bold
-              ¥ 680
+              ¥ #{@product.price.to_s(:delimited)}
               %span.item-shipping-fee.f14.bold
-                送料込み
+                = fee_decide(@product)
             %ul.buy-accordion.not-have
               %li.accrodion-parent
                 .accrodion-toggle ポイントはありません
             %ul.buy-price-table
               %li.buy-price-row.buy-you-pay.bold
               %li.buy-price-cell 支払い金額
-              %li.buy-price-cell ¥ 680
+              %li.buy-price-cell ¥ #{@product.price.to_s(:delimited)}
             = f.submit "購入する", class: "btn-buy bold"
 
       %section.buy-content.buy-user-info
         .buy-content-inner
           %h3 配送先
           %address.buy-user-info-text
-            〒633-0376
+            〒
+            = zip_code(@profile)
             %br
-            東京都 相楽郡精華町桜ヶ丘 4-37-9
+            = set_address(@profile)
             %br
-            メルコリ 太郎
+            = set_name(@profile)
           = link_to "#", class: "buy-user-info-fix" do
             %span 変更する
             %i.fas.fa-angle-right.arrow-right

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -52,7 +52,7 @@
           %th.item-detail__th ブランド
           %td.item-detail__td
             = link_to "#", class: "" do
-              %text シャネル
+              %text
         %tr
           %th.item-detail__th 商品の状態
           %td.item-detail__td
@@ -82,7 +82,7 @@
     %span.item-box__box-price--shipping-fee
       = fee_decide(@product)
   - if @product.status == 0
-    = link_to '購入画面に進む', "#", class: "item-buy-btn"
+    = link_to '購入画面に進む', buy_product_path(@product.id), class: "item-buy-btn"
   - else
     = link_to '売り切れました', "#", class: "item-buy-btn disabled"
   - if @user.id == current_user.id
@@ -137,7 +137,7 @@
 .body-items
   %section.body-items-box
     %h2.body-items-box__box-head
-      = link_to '小林タロウさんのその他の出品', "#", class: "body-items-box__box-head--link"
+      = link_to "#{@user.nickname}さんのその他の出品", "#", class: "body-items-box__box-head--link"
     %section.body-items-box__item-box
       = link_to "http://www.google.co.jp/", class: "body-items-box__item-box--link" do
         %figure.item-box-photo
@@ -165,88 +165,6 @@
           .item-box-body__num
             .item-box-body__num--price ¥ 1,190
             %p.item-box-body__num--tax (税込)
-    %section.body-items-box__item-box
-      = link_to "http://www.google.co.jp/", class: "body-items-box__item-box--link" do
-        %figure.item-box-photo
-          = image_tag 'https://static-mercari-jp-imgtr2.akamaized.net/thumb/photos/m37415570207_1.jpg?1550117821', class: "item-box-photo__img"
-        .item-box-body
-          %h3.item-box-body__name セットアップ  スーツ  入学式  卒業式  レディース 9号
-          .item-box-body__num
-            .item-box-body__num--price ¥ 1,190
-            %p.item-box-body__num--tax (税込)
-    %section.body-items-box__item-box
-      = link_to "http://www.google.co.jp/", class: "body-items-box__item-box--link" do
-        %figure.item-box-photo
-          = image_tag 'https://static-mercari-jp-imgtr2.akamaized.net/thumb/photos/m37415570207_1.jpg?1550117821', class: "item-box-photo__img"
-        .item-box-body
-          %h3.item-box-body__name セットアップ  スーツ  入学式  卒業式  レディース 9号
-          .item-box-body__num
-            .item-box-body__num--price ¥ 1,190
-            %p.item-box-body__num--tax (税込)
-    %section.body-items-box__item-box
-      = link_to "http://www.google.co.jp/", class: "body-items-box__item-box--link" do
-        %figure.item-box-photo
-          = image_tag 'https://static-mercari-jp-imgtr2.akamaized.net/thumb/photos/m37415570207_1.jpg?1550117821', class: "item-box-photo__img"
-        .item-box-body
-          %h3.item-box-body__name セットアップ  スーツ  入学式  卒業式  レディース 9号
-          .item-box-body__num
-            .item-box-body__num--price ¥ 1,190
-            %p.item-box-body__num--tax (税込)
-  %section.body-items-box
-    %h2.body-items-box__box-head
-      = link_to 'シャネルのブレスレッド その他の商品', "#", class: "body-items-box__box-head--link"
-    %section.body-items-box__item-box
-      = link_to "http://www.google.co.jp/", class: "body-items-box__item-box--link" do
-        %figure.item-box-photo
-          = image_tag 'https://static-mercari-jp-imgtr2.akamaized.net/thumb/photos/m37415570207_1.jpg?1550117821', class: "item-box-photo__img"
-        .item-box-body
-          %h3.item-box-body__name セットアップ  スーツ  入学式  卒業式  レディース 9号
-          .item-box-body__num
-            .item-box-body__num--price ¥ 1,190
-            %p.item-box-body__num--tax (税込)
-    %section.body-items-box__item-box
-      = link_to "http://www.google.co.jp/", class: "body-items-box__item-box--link" do
-        %figure.item-box-photo
-          = image_tag 'https://static-mercari-jp-imgtr2.akamaized.net/thumb/photos/m37415570207_1.jpg?1550117821', class: "item-box-photo__img"
-        .item-box-body
-          %h3.item-box-body__name セットアップ  スーツ  入学式  卒業式  レディース 9号
-          .item-box-body__num
-            .item-box-body__num--price ¥ 1,190
-            %p.item-box-body__num--tax (税込)
-    %section.body-items-box__item-box
-      = link_to "http://www.google.co.jp/", class: "body-items-box__item-box--link" do
-        %figure.item-box-photo
-          = image_tag 'https://static-mercari-jp-imgtr2.akamaized.net/thumb/photos/m37415570207_1.jpg?1550117821', class: "item-box-photo__img"
-        .item-box-body
-          %h3.item-box-body__name セットアップ  スーツ  入学式  卒業式  レディース 9号
-          .item-box-body__num
-            .item-box-body__num--price ¥ 1,190
-            %p.item-box-body__num--tax (税込)
-    %section.body-items-box__item-box
-      = link_to "http://www.google.co.jp/", class: "body-items-box__item-box--link" do
-        %figure.item-box-photo
-          = image_tag 'https://static-mercari-jp-imgtr2.akamaized.net/thumb/photos/m37415570207_1.jpg?1550117821', class: "item-box-photo__img"
-        .item-box-body
-          %h3.item-box-body__name セットアップ  スーツ  入学式  卒業式  レディース 9号
-          .item-box-body__num
-            .item-box-body__num--price ¥ 1,190
-            %p.item-box-body__num--tax (税込)
-    %section.body-items-box__item-box
-      = link_to "http://www.google.co.jp/", class: "body-items-box__item-box--link" do
-        %figure.item-box-photo
-          = image_tag 'https://static-mercari-jp-imgtr2.akamaized.net/thumb/photos/m37415570207_1.jpg?1550117821', class: "item-box-photo__img"
-        .item-box-body
-          %h3.item-box-body__name セットアップ  スーツ  入学式  卒業式  レディース 9号
-          .item-box-body__num
-            .item-box-body__num--price ¥ 1,190
-            %p.item-box-body__num--tax (税込)
-    %section.body-items-box__item-box
-      = link_to "http://www.google.co.jp/", class: "body-items-box__item-box--link" do
-        %figure.item-box-photo
-          = image_tag 'https://static-mercari-jp-imgtr2.akamaized.net/thumb/photos/m37415570207_1.jpg?1550117821', class: "item-box-photo__img"
-        .item-box-body
-          %h3.item-box-body__name セットアップ  スーツ  入学式  卒業式  レディース 9号
-          .item-box-body__num
-            .item-box-body__num--price ¥ 1,190
-            %p.item-box-body__num--tax (税込)
+
+= render 'layouts/global-banner'
 = render 'layouts/global-footer'

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -25,7 +25,6 @@ describe ProductsController, type: :controller do
     context "with valid params" do
       it "creates a new Product" do
         params = { images_attributes: [ attributes_for( :image ) ] }
-        binding.pry
         expect {
           post :create,
           product: build( :product ).merge( params )


### PR DESCRIPTION
#  What
・商品購入ページ内にて、ユーザー情報および商品情報を表示できるようにしました。

# Why
購入前に商品情報を確認できるようにするため。


実際のビュー画面になります。
https://gyazo.com/55175402295879b9836629f93e4545a8