### PR TITLE
before_action処理の追加

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -1,6 +1,7 @@
 class PaymentsController < ApplicationController
   before_action :authenticate_user!
   before_action :Set_api_for_payjp, only: :create
+  before_action :payment_check, only: :new
 
   def new
     @payment = Payment.new
@@ -14,6 +15,10 @@ class PaymentsController < ApplicationController
     else
       redirect_to new_payment_path
     end
+  end
+
+  def payment_check
+    redirect_to root_path unless Payment.where(user_id: current_user.id).blank?
   end
 
 end

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -17,6 +17,7 @@ class PaymentsController < ApplicationController
     end
   end
 
+  private
   def payment_check
     redirect_to root_path unless Payment.where(user_id: current_user.id).blank?
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,7 +2,7 @@ class ProductsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit, :buy]
   before_action :set_form_data, only: [:new, :edit]
   before_action :check_seller?, only: :edit
-  before_action :check_card, only: :buy
+  before_action :check_user, only: :buy
   before_action :Set_api_for_payjp, only: :buy
 
   def index
@@ -128,8 +128,12 @@ class ProductsController < ApplicationController
     redirect_to product_path unless product.seller_id == current_user.id
   end
 
-  def check_card
-    redirect_to root_path unless Payment.where(user_id: current_user.id).blank?
+  def check_user
+    if Profile.where(user_id: current_user.id).blank?
+      redirect_to new_profile_path
+    elsif Payment.where(user_id: current_user.id).blank?
+      redirect_to new_payment_path
+    end
   end
 
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,8 @@
 class ProductsController < ApplicationController
-  before_action :authenticate_user!, only: :new
+  before_action :authenticate_user!, only: [:new, :edit, :buy]
   before_action :set_form_data, only: [:new, :edit]
+  before_action :check_seller?, only: :edit
+  before_action :check_card, only: :buy
   before_action :Set_api_for_payjp, only: :buy
 
   def index
@@ -119,6 +121,15 @@ class ProductsController < ApplicationController
 
   def search_product(category)
     return Product.where(category_id: category.subtree_ids).limit(4).order("created_at DESC")
+  end
+
+  def check_seller?
+    product = Product.find(params[:id])
+    redirect_to product_path unless product.seller_id == current_user.id
+  end
+
+  def check_card
+    redirect_to root_path unless Payment.where(user_id: current_user.id).blank?
   end
 
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,4 +1,5 @@
 class ProductsController < ApplicationController
+  before_action :authenticate_user!, only: :new
   before_action :set_form_data, only: [:new, :edit]
   before_action :Set_api_for_payjp, only: :buy
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
+  before_action :profile_check, only: :new
 
   def new
     @profiles = Profile.new
@@ -13,6 +14,10 @@ class ProfilesController < ApplicationController
         flash.now[:alert] = '未入力項目があります'
         render :new
     end
+  end
+
+  def profile_check
+    redirect_to root_path unless Profile.where(user_id: current_user.id).blank?
   end
 
   private

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -16,13 +16,13 @@ class ProfilesController < ApplicationController
     end
   end
 
-  def profile_check
-    redirect_to root_path unless Profile.where(user_id: current_user.id).blank?
-  end
-
   private
   def profile_params
     params.require(:profile).permit(:first_name, :last_name, :first_name_kana, :last_name_kana, :birthdate, :zip_code, :prefecture, :city, :address1, :address2, :phone_number, ).merge(user_id: current_user.id)
+  end
+
+  def profile_check
+    redirect_to root_path unless Profile.where(user_id: current_user.id).blank?
   end
 
 end

--- a/app/views/likes/_like_links.html.haml
+++ b/app/views/likes/_like_links.html.haml
@@ -1,5 +1,5 @@
 %div.like-link{id: "like-link-#{product.id}"}
-  - if current_user.already_liked?(product)
+  - if user_signed_in? && current_user.already_liked?(product)
     =link_to unlike_path(product.id), method: :delete, remote: true, class: "item-box__btn-container-left--liked item-button__liked", id: "heart-#{product.id} l" do
       %i.fas.fa-heart
       %span いいね!

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -85,7 +85,7 @@
     = link_to '購入画面に進む', "#", class: "item-buy-btn"
   - else
     = link_to '売り切れました', "#", class: "item-buy-btn disabled"
-  - if @user.id == current_user.id
+  - if user_signed_in? && @user.id == current_user.id
     = link_to '商品の編集', edit_product_path(@product.id), class: "item-buy-btn"
     = link_to 'この商品を削除する', product_path(@product.id), method: :delete, class: "item-buy-btn disabled"
   .item-box__box-descriotion

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,5 +1,4 @@
 crumb :root do
-  # binding.pry
   link 'メルカリ', root_path
 end
 


### PR DESCRIPTION
# WHAT
### before_actionでの変更
・ログインしていないユーザーが商品出品画面に遷移しようとした際、トップページに遷移するようにしました。

・出品したユーザー以外が商品編集画面に遷移しようとした際、商品詳細画面に遷移するようにしました。

・カード情報とプロフィール情報を持っていないユーザーが商品購入画面に遷移しようとした際、それぞれの登録画面に遷移するようにしました。

・プロフィールとカード情報を持っているユーザーが新規作成画面に遷移しようとした際、トップページに遷移するようにしました。

### view側の変更
下記のファイルの条件分岐を変更し、ログインしていないユーザーも商品詳細画面に遷移できるように変更しました。
>like_links.html.haml
show.html.haml
# WHY
before_actionの変更はエラー回避のために実装しました。
商品詳細画面の表示をログインしていないユーザーにも出来るようにすることでユーザーの利便性を良くしました。