### PR TITLE
メールアドレスでのログイン時の調整

### DIFF
--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -23,7 +23,7 @@
             %a.google-btn{:href => 'auth/google_oauth2/'}
               Googleでログイン
 
-          = form_with(model: resource, as: resource_name, url: user_session_path, locla: true) do |form|
+          = form_with(model: resource, as: resource_name, url: user_session_path, local: true) do |form|
             .register-inner__content
               .form-group
                 = form.email_field :email, placeholder: "メールアドレス", class:"input-default"


### PR DESCRIPTION
# WHAT
form_withのオプションのスペルミスの修正
# WHY
メールアドレスでログインした際、トップページに遷移させることでログインが完了したとユーザーに分かりやすくする為。