### PR TITLE
進捗バー修正＆ログアウト遷移ページへのユーザー制限追加

### DIFF
--- a/app/assets/stylesheets/mixin/user_registration_common_parts.scss
+++ b/app/assets/stylesheets/mixin/user_registration_common_parts.scss
@@ -42,12 +42,12 @@ $white: #FFFFFF;
     display: flex;
     width: 500px;
     .activ-box{
-      margin: 5% 7% 5% 7%;
+      margin: 5% 0% 5% 0%;
       .active{
         font-size: 12px;
         font-weight: 600;
         color: #ea352d;
-        width: 65px;
+        width: 134px;
         text-align: center;
       }
     }

--- a/app/assets/stylesheets/mixin/user_registration_common_parts.scss
+++ b/app/assets/stylesheets/mixin/user_registration_common_parts.scss
@@ -40,48 +40,108 @@ $white: #FFFFFF;
 @mixin progress-bar{
   .clearfix{
     display: flex;
+    width: 500px;
     .activ-box{
-      width: auto;
-      display: flex;
-      align-items: center;
-      margin:2vw 2vw 1vw 2vw;
+      margin: 5% 7% 5% 7%;
       .active{
-        font-size: 0.9vw;
-        margin:auto auto 20px auto;
+        font-size: 12px;
         font-weight: 600;
         color: #ea352d;
-        cursor: pointer;
+        width: 65px;
+        text-align: center;
       }
     }
   }
 }
 
-// 進捗状況の丸印の部分  ーーーーーーーーーーーーー
+// 進捗バー 右赤色 ----------------------------
 
-@mixin progress-status{
+@mixin progress-right-red{
+  width: 15px;
+  height: 15px;
+  margin: 20px auto;
+  background: #ea352d;
+  border-radius: 50%;
+  &:after{
+    display: flex;
+    border-bottom:solid 2px #ea352d;
+    content:'';
+    width:73px;
+    padding: 3px;
+  }
+}
+
+// 進捗バー両端グレー ーーーーーーーーーーーーーー
+
+@mixin progress-wside-gray{
+  width: 15px;
+  height: 15px;
+  margin: 20px auto;
+  background: #ea352d;
+  border-radius: 50%;
+  &:after{
+    position:absolute;
+    border-bottom:solid 2px #ccc;
+    content:'';
+    width: 63px;
+    height: 6px;
+    margin-left: 8px;
+  }
+  &:before{
+    position:absolute;
+    border-bottom:solid 2px #ccc;
+    content:'';
+    width: 58px;
+    height: 6px;
+    margin-left: -66px;
+  }
+}
+
+// 進捗バー両端赤色ーーーーーーーーーーーーーーー
+
+@mixin progress-wside-red{
+  width: 15px;
+  height: 15px;
+  margin: 20px auto;
+  background: #ea352d;
+  border-radius: 50%;
+  &:after{
+    position:absolute;
+    border-bottom:solid 2px #ea352d;
+    content:'';
+    width: 65px;
+    height: 6px;
+    margin-left: 7px;
+  }
+  &:before{
+    position:absolute;
+    border-bottom:solid 2px #ea352d;
+    content:'';
+    width: 58px;
+    height: 6px;
+    margin-left: -65px;
+  }
+}
+
+// 進捗バー左グレーーーーーーーーーーーーーーーーー
+
+@mixin progress-left-gray{
   width: 15px;
   height: 15px;
   margin: 20px auto;
   background: #ccc;
   border-radius: 50%;
+  &:before{
+    position:absolute;
+    border-bottom:solid 2px #ccc;
+    content:'';
+    width: 58px;
+    height: 6px;
+    margin-left: -65px;
+  }
 }
 
-
-// 進捗情報の文字を赤色に入れる処理-------------
-
-@mixin active-red{
-  font-size: 0.9vw;
-  margin:auto auto 20px auto;
-  font-weight: 600;
-  color: #ea352d;
-  cursor: pointer;
-  margin:auto auto 20px auto;
-  font-weight: 600;
-  color: $light_red;
-  cursor: pointer;
-}
-
-// 会員情報登録のセンター部分の枠 ーーーーーーーー
+// 会員情報登録センター部分の枠 ーーーーーーーー
 
 @mixin register-main{
   width: 700px;

--- a/app/assets/stylesheets/mixin/user_registration_common_parts.scss
+++ b/app/assets/stylesheets/mixin/user_registration_common_parts.scss
@@ -7,7 +7,6 @@ $white: #FFFFFF;
 
 @mixin campany-logo{
   width: 180px;
-  cursor: pointer;
 }
 
 // 会員登録ページ ヘッダー ーーーーーーーーーーー

--- a/app/assets/stylesheets/payments/payments.scss
+++ b/app/assets/stylesheets/payments/payments.scss
@@ -70,3 +70,19 @@
   -webkit-transform: translate(0, -50%);
   transform: translate(0, -50%);
 }
+
+.progress-right-red{
+  @include progress-right-red
+}
+
+.progress-wside-gray{
+   @include progress-wside-gray
+}
+
+.progress-wside-red{
+   @include progress-wside-red
+}
+
+.progress-left-gray{
+   @include progress-left-gray
+}

--- a/app/assets/stylesheets/profiles/profiles.scss
+++ b/app/assets/stylesheets/profiles/profiles.scss
@@ -1,27 +1,26 @@
 
 .register-info{
-  width: 24vw;
+  width: 329px;
   margin: auto;
-  font-size: 1vw;
-  line-height: 1.8vmax;
+  font-size: 14px;
+  line-height: 2;
   letter-spacing: 0.1vh;
   display: flex;
   justify-content: center;
   align-items: center;
-  padding-top: 5vh;
+  padding-top: 30px;
 }
 
 .register-pass-upload{
-  font-size: 1vw;
-  padding-left: 45%;
-  margin-top:5vh;
+  font-size: 13px;
+  padding-left: 146px;
+  margin-top: 5px;
   color: #0099e8;
   cursor: pointer;
 }
 
 
 .birthdate_date_box{
-  // display: flex;
   width: 100%;
   #profile_birthdate_1i,#profile_birthdate_2i,#profile_birthdate_3i{
     -webkit-appearance: none;
@@ -57,3 +56,20 @@
   margin-left: 15px;
   color: gray;
 }
+
+.progress-right-red{
+  @include progress-right-red
+}
+
+.progress-wside-gray{
+   @include progress-wside-gray
+}
+
+.progress-wside-red{
+   @include progress-wside-red
+}
+
+.progress-left-gray{
+   @include progress-left-gray
+}
+

--- a/app/assets/stylesheets/users/registration_select.scss
+++ b/app/assets/stylesheets/users/registration_select.scss
@@ -25,3 +25,7 @@
   align-items: center;
 }
 
+.register_logo_link{
+  display: flex;
+  cursor: pointer;
+}

--- a/app/assets/stylesheets/users/users.scss
+++ b/app/assets/stylesheets/users/users.scss
@@ -11,10 +11,6 @@
   @include progress-bar
 }
 
-.progress-status{
-  @include progress-status
-}
-
 .register-main{
   @include register-main
 }
@@ -33,4 +29,20 @@
 
 .register__container__footer{
   @include register__container__footer
+}
+
+.progress-right-red{
+  @include progress-right-red
+}
+
+.progress-wside-gray{
+   @include progress-wside-gray
+}
+
+.progress-wside-red{
+   @include progress-wside-red
+}
+
+.progress-left-gray{
+   @include progress-left-gray
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!, only: [:signout]
+  before_action :authenticate_user!, only: [:logout]
   before_action :set_user, only: [:show, :update]
 
 

--- a/app/views/payments/new.html.haml
+++ b/app/views/payments/new.html.haml
@@ -6,19 +6,19 @@
         .activ-box
           %li.active
             会員情報
-            .progress-status
+            .progress-right-red
         .activ-box
           %li.active
             連絡先情報
-            .progress-status
+            .progress-wside-red
         .activ-box
           %li.active
             支払い方法
-            .progress-status
+            .progress-wside-red
         .activ-box
           %li.active
             完了
-            .progress-status
+            .progress-left-gray
   %main.register-main
     %section.register-main__container
       %h2.register-main__container--header 支払い方法

--- a/app/views/profiles/new.html.haml
+++ b/app/views/profiles/new.html.haml
@@ -6,19 +6,19 @@
         .activ-box
           %li.active
             会員情報
-            .progress-status
+            .progress-right-red
         .activ-box
           %li.active
             連絡先情報
-            .progress-status
+            .progress-wside-red
         .activ-box
           %li.active
             支払い方法
-            .progress-status
+            .progress-wside-gray
         .activ-box
           %li.active
             完了
-            .progress-status
+            .progress-left-gray
   %main.register-main
     %section.register-main__container
       %h2.register-main__container--header 連絡先情報登録

--- a/app/views/users/registration_select.html.haml
+++ b/app/views/users/registration_select.html.haml
@@ -1,6 +1,7 @@
 .register__container
   .register__container__header
-    = image_tag "logo.svg", class:"campany-logo", alt:"メルカリロゴ"
+    = link_to root_path, class:"register_logo_link" do
+      = image_tag "logo.svg", class:"campany-logo", alt:"メルカリロゴ"
 
   %main.register-main
     %section.register-main__container

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -1,25 +1,24 @@
 .register__container
   .register__container__header
     = image_tag "logo.svg", class:"campany-logo", alt:"メルカリロゴ"
-    %nav.progress-status-first
+    %nav.progress-bar
       %ol.clearfix
         .activ-box
-          %li.active-red
+          %li.active
             会員情報
-            .progress-status
+            .progress-right-red
         .activ-box
           %li.active
             連絡先情報
-            .progress-status
+            .progress-wside-gray
         .activ-box
           %li.active
             支払い方法
-            .progress-status
+            .progress-wside-gray
         .activ-box
           %li.active
             完了
-            .progress-status
-
+            .progress-left-gray
   %main.register-main
     %section.register-main__container
       %h2.register-main__container--header 会員情報入力

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -1,6 +1,7 @@
 .register__container
   .register__container__header
-    = image_tag "logo.svg", class:"campany-logo", alt:"メルカリロゴ"
+    = link_to root_path, class:"register_logo_link" do
+      = image_tag "logo.svg", class:"campany-logo", alt:"メルカリロゴ"
 
   %main.register-select-main
     %section.register-main__container


### PR DESCRIPTION
# WHAT
- ユーザー会員登録の進捗バーに変更。
- ログアウト遷移ページへのユーザー制限追加。
- ログイン画面、新規会員登録のロゴにlink_toでroot_pathを追加。

# WHY
- ユーザー会員登録の進捗バーに赤色で進捗状況が視覚的に分かり易いViewにいたしました。
- ログアウトページはログインユーザーでない限り入れない制限を設けました。
- ログイン画面、新規会員登録のロゴにlink_toでroot_pathを追加し直感的に遷移し易い更新を行いました。