### PR TITLE
検索後の画像内にLink_to追加、検索ページView幅微調整

### DIFF
--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -1,5 +1,5 @@
 .serch-page{
-  width: 1100px;
+  width: 1070px;
   margin: auto;
   height:100%;
   display: flex;
@@ -29,6 +29,7 @@
 
 .search-right-section{
   margin-top:28px;
+  margin-left: 30px;
   width: 750px;
   height: 100%;
   padding: 1%;

--- a/app/views/products/_show-box.haml
+++ b/app/views/products/_show-box.haml
@@ -1,5 +1,5 @@
 .show-box
-  = link_to "#", class: "body-items-box__item-box--link" do
+  = link_to product_path(product.id), class: "body-items-box__item-box--link" do
     .show-box_image
       .show-box_image--inner
         = image_tag product.images[0].image_path_url, class: "item-box-photo__img"


### PR DESCRIPTION
# WHAT
- 検索後の画像内にLink_to追加
- 検索ページView幅微調整

# WHY
- 画像をクリックしても商品詳細に遷移していなかったためにLink_toを追加いたしました。
- 検索ページのViewが若干左寄りであったため幅の微調整を行いました。