### PR TITLE
商品出品時に画像のバリデーション追加

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -26,6 +26,7 @@ class Product < ApplicationRecord
   validates :price, numericality: { only_integer: true }
   validates :price, numericality: { greater_than_or_equal_to: 300 }  # 数字が5以上であるか
   validates :price, numericality: { less_than_or_equal_to: 9999999 }
+  validates :images, presence: true
 
   enum condition: {
     unused: 1,


### PR DESCRIPTION
# WHAT
商品を出品する際に画像が添付されていないと商品が出品できないようにバリデーションをかけました
# WHY
画像がない商品が出品された際、エラーが発生してアプリが動かなくなる問題をなくす為。